### PR TITLE
Fixing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,15 +55,17 @@
     "express": "^4.14.0",
     "istanbul": "^1.0.0-alpha.2",
     "json-loader": "^0.5.4",
-    "kinvey-node-sdk": "../../Node/SDK",
+    "kinvey-node-sdk": "^3.2.0",
     "lodash": "^4.16.2",
     "mocha": "^2.5.3",
     "nock": "^8.0.0",
-    "protractor": "^4.0.8",
     "shelljs": "^0.7.4",
     "uglify-js": "^2.7.3",
     "webdriver-manager": "^10.2.3",
     "webpack": "^1.13.0"
+  },
+  "devDependencies": {
+    "protractor": "^4.0.8"
   },
   "engines": {
     "node": ">=4.0"


### PR DESCRIPTION
#### Description

This PR solves the following problem that was reported to us - 

> Our company uses a sonatype/Nexus2.0 repository manager that store our internal repository then access to other public dependencies like kinvey from it.
> Since kinvey-html5-sdk@3.2.0, some of the dependencies (couldn't identify which one) require a set of dependencies starting with @ which is currently not compatible with our repository manager. In our case, the issue is coming with @type : https://github.com/DefinitelyTyped/DefinitelyTyped
#### Changes
- The `protractor` dependency was causing the creation of the `@type` directory. Moving this dependency to `devDependencies` should avoid it (`protractor` is used for tests)
- The dependency on `kinvey-node-sdk` should point to the `npm` package, not a local path. This is fixed.
