### PR TITLE
MLIBZ-1593 Don't open two databases to check support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,5 +36,8 @@
     "es6": true,
     "mocha": true,
     "node": true
+  },
+  "globals": {
+    "SQLError": true
   }
 }

--- a/src/middleware/src/storage/index.js
+++ b/src/middleware/src/storage/index.js
@@ -1,31 +1,32 @@
 import KinveyStorage from 'kinvey-node-sdk/dist/request/src/middleware/src/storage';
+import { isDefined } from 'kinvey-node-sdk/dist/utils';
 import IndexedDB from './src/indexeddb';
 import WebSQL from './src/websql';
 import { LocalStorage } from './src/webstorage';
 
 export default class Storage extends KinveyStorage {
   getAdapter() {
-    return WebSQL.isSupported()
-      .then((isWebSQLSupported) => {
-        if (isWebSQLSupported) {
-          return new WebSQL(this.name);
+    return WebSQL.loadAdapter(this.name)
+      .then((adapter) => {
+        if (isDefined(adapter) === false) {
+          return IndexedDB.loadAdapter(this.name);
         }
 
-        return IndexedDB.isSupported()
-          .then((isIndexedDBSupported) => {
-            if (isIndexedDBSupported) {
-              return new IndexedDB(this.name);
-            }
+        return adapter;
+      })
+      .then((adapter) => {
+        if (isDefined(adapter) === false) {
+          return LocalStorage.loadAdapter(this.name);
+        }
 
-            return LocalStorage.isSupported()
-              .then((isLocalStorageSupported) => {
-                if (isLocalStorageSupported) {
-                  return new LocalStorage(this.name);
-                }
+        return adapter;
+      })
+      .then((adapter) => {
+        if (isDefined(adapter) === false) {
+          return super.getAdapter();
+        }
 
-                return super.getAdapter();
-              });
-          });
+        return adapter;
       });
   }
 }

--- a/src/middleware/src/storage/src/indexeddb.js
+++ b/src/middleware/src/storage/src/indexeddb.js
@@ -5,7 +5,7 @@ import isString from 'lodash/isString';
 import isArray from 'lodash/isArray';
 import isFunction from 'lodash/isFunction';
 let dbCache = {};
-let isSupported = undefined;
+let isSupported;
 
 const TransactionMode = {
   ReadWrite: 'readwrite',
@@ -273,28 +273,31 @@ export default class IndexedDB {
     });
   }
 
-  static isSupported() {
-    const name = 'testIndexedDBSupport';
+  static loadAdapter(name) {
     const indexedDB = global.indexedDB || global.webkitIndexedDB || global.mozIndexedDB || global.msIndexedDB;
-
-    if (typeof indexedDB === 'undefined') {
-      return Promise.resolve(false);
-    }
+    const db = new IndexedDB(name);
 
     if (typeof isSupported !== 'undefined') {
-      return Promise.resolve(isSupported);
+      if (isSupported) {
+        return Promise.resolve(db);
+      }
+
+      return Promise.resolve(undefined);
     }
 
-    const db = new IndexedDB(name);
-    return db.save(name, { _id: '1' })
-      .then(() => db.clear())
+    if (typeof indexedDB === 'undefined') {
+      isSupported = false;
+      return Promise.resolve(undefined);
+    }
+
+    return db.save('__testSupport', { _id: '1' })
       .then(() => {
         isSupported = true;
-        return true;
+        return db;
       })
       .catch(() => {
         isSupported = false;
-        return false;
+        return undefined;
       });
   }
 }

--- a/src/middleware/src/storage/src/websql.js
+++ b/src/middleware/src/storage/src/websql.js
@@ -7,20 +7,20 @@ import isFunction from 'lodash/isFunction';
 import isString from 'lodash/isString';
 const idAttribute = process.env.KINVEY_ID_ATTRIBUTE || '_id';
 const masterCollectionName = 'sqlite_master';
-const size = 5 * 1000 * 1000; // Database size in bytes
 let dbCache = {};
-let isSupported = undefined;
+let isSupported;
 
 export default class WebSQL {
-  constructor(name = 'kinvey') {
+  constructor(name = 'kinvey', size = 5000) {
     this.name = name;
+    this.size = size;
   }
 
   openDatabase() {
     let db = dbCache[this.name];
 
     if (!db) {
-      db = global.openDatabase(this.name, 1, '', size);
+      db = global.openDatabase(this.name, 1, '', this.size);
       dbCache[this.name] = db;
     }
 
@@ -190,7 +190,7 @@ export default class WebSQL {
         // Drop all tables. Filter tables first to avoid attempting to delete
         // system tables (which will fail).
         const queries = tables
-          .filter(table => (/^[a-zA-Z0-9\-]{1,128}/).test(table))
+          .filter(table => (/^[a-zA-Z0-9-]{1,128}/).test(table))
           .map(table => [`DROP TABLE IF EXISTS '${table}'`]);
         return this.openTransaction(masterCollectionName, queries, null, true);
       })
@@ -200,27 +200,30 @@ export default class WebSQL {
       });
   }
 
-  static isSupported() {
-    const name = 'testWebSQLSupport';
-
-    if (typeof global.openDatabase === 'undefined') {
-      return Promise.resolve(false);
-    }
+  static loadAdapter(name) {
+    const db = new WebSQL(name);
 
     if (typeof isSupported !== 'undefined') {
-      return Promise.resolve(isSupported);
+      if (isSupported) {
+        return Promise.resolve(db);
+      }
+
+      return Promise.resolve(undefined);
     }
 
-    const db = new WebSQL(name);
-    return db.save(name, { _id: '1' })
-      .then(() => db.clear())
+    if (typeof global.openDatabase === 'undefined') {
+      isSupported = false;
+      return Promise.resolve(undefined);
+    }
+
+    return db.save('__testSupport', { _id: '1' })
       .then(() => {
         isSupported = true;
-        return true;
+        return db;
       })
       .catch(() => {
         isSupported = false;
-        return false;
+        return undefined;
       });
   }
 }

--- a/src/middleware/src/storage/src/websql.js
+++ b/src/middleware/src/storage/src/websql.js
@@ -9,7 +9,7 @@ const idAttribute = process.env.KINVEY_ID_ATTRIBUTE || '_id';
 const masterCollectionName = 'sqlite_master';
 let dbCache = {};
 let isSupported;
-const SIZE = 5000;
+const SIZE = 5 * 1000 * 1000; // 5mb
 
 export default class WebSQL {
   constructor(name = 'kinvey') {

--- a/src/middleware/src/storage/src/websql.js
+++ b/src/middleware/src/storage/src/websql.js
@@ -9,18 +9,18 @@ const idAttribute = process.env.KINVEY_ID_ATTRIBUTE || '_id';
 const masterCollectionName = 'sqlite_master';
 let dbCache = {};
 let isSupported;
+const SIZE = 5000;
 
 export default class WebSQL {
-  constructor(name = 'kinvey', size = 5000) {
+  constructor(name = 'kinvey') {
     this.name = name;
-    this.size = size;
   }
 
   openDatabase() {
     let db = dbCache[this.name];
 
     if (!db) {
-      db = global.openDatabase(this.name, 1, '', this.size);
+      db = global.openDatabase(this.name, 1, '', SIZE);
       dbCache[this.name] = db;
     }
 

--- a/src/middleware/src/storage/src/websql.js
+++ b/src/middleware/src/storage/src/websql.js
@@ -75,7 +75,7 @@ export default class WebSQL {
               if (pending === 0) {
                 resolve(isMulti ? responses : responses.shift());
               }
-            }, () => false); // Returning true to rollback, false to continue the transaction
+            });
           });
         }
       }, (error) => {
@@ -83,7 +83,7 @@ export default class WebSQL {
 
         // Safari calls this function regardless if user permits more quota or not.
         // And there's no way for a developer to know user's reaction.
-        if (error && error.code === SQLError.QUOTA_ERR) {
+        if (error && typeof SQLError !== 'undefined' && error.code === SQLError.QUOTA_ERR) {
           // Start over the transaction again to check if user permitted or not.
           return this.openTransaction(collection, query, parameters, write);
         }

--- a/src/middleware/src/storage/src/websql.js
+++ b/src/middleware/src/storage/src/websql.js
@@ -75,21 +75,28 @@ export default class WebSQL {
               if (pending === 0) {
                 resolve(isMulti ? responses : responses.shift());
               }
-            });
+            }, () => false); // Returning true to rollback, false to continue the transaction
           });
         }
       }, (error) => {
         error = isString(error) ? error : error.message;
+
+        // Safari calls this function regardless if user permits more quota or not.
+        // And there's no way for a developer to know user's reaction.
+        if (error && error.code === SQLError.QUOTA_ERR) {
+          // Start over the transaction again to check if user permitted or not.
+          return this.openTransaction(collection, query, parameters, write);
+        }
 
         if (error && error.indexOf('no such table') === -1) {
           return reject(new NotFoundError(`The ${collection} collection was not found on`
             + ` the ${this.name} WebSQL database.`));
         }
 
-        const query = 'SELECT name AS value from #{collection} WHERE type = ? AND name = ?';
-        const parameters = ['table', collection];
+        const checkQuery = 'SELECT name AS value from #{collection} WHERE type = ? AND name = ?';
+        const checkParameters = ['table', collection];
 
-        return this.openTransaction(masterCollectionName, query, parameters).then((response) => {
+        return this.openTransaction(masterCollectionName, checkQuery, checkParameters).then((response) => {
           if (response.result.length === 0) {
             return reject(new NotFoundError(`The ${collection} collection was not found on`
               + ` the ${this.name} WebSQL database.`));

--- a/src/middleware/src/storage/src/webstorage.js
+++ b/src/middleware/src/storage/src/webstorage.js
@@ -130,6 +130,22 @@ export class LocalStorage extends WebStorage {
 
     return Promise.resolve(false);
   }
+
+  static loadAdapter(name) {
+    if (global.localStorage) {
+      const item = '__testSupport';
+      try {
+        global.localStorage.setItem(item, item);
+        global.localStorage.getItem(item);
+        global.localStorage.removeItem(item);
+        return Promise.resolve(new LocalStorage(name));
+      } catch (e) {
+        return Promise.resolve(undefined);
+      }
+    }
+
+    return Promise.resolve(undefined);
+  }
 }
 
 export class SessionStorage extends WebStorage {
@@ -228,20 +244,20 @@ export class SessionStorage extends WebStorage {
       });
   }
 
-  static isSupported() {
+  static loadAdapter(name) {
     if (global.sessionStorage) {
-      const item = 'testSessionStorageSupport';
+      const item = '__testSupport';
       try {
         global.sessionStorage.setItem(item, item);
-        gloabl.sessionStorage.getItem(item);
+        global.sessionStorage.getItem(item);
         global.sessionStorage.removeItem(item);
-        return Promise.resolve(true);
+        return Promise.resolve(new LocalStorage(name));
       } catch (e) {
-        return Promise.resolve(false);
+        return Promise.resolve(undefined);
       }
     }
 
-    return Promise.resolve(false);
+    return Promise.resolve(undefined);
   }
 }
 
@@ -353,5 +369,13 @@ export class CookieStorage extends WebStorage {
 
   static isSupported() {
     return Promise.resolve(typeof global.document.cookie !== 'undefined');
+  }
+
+  static loadAdapter(name) {
+    if (typeof global.document.cookie === 'undefined') {
+      return Promise.resolve(undefined);
+    }
+
+    return Promise.resolve(new CookieStorage(name));
   }
 }


### PR DESCRIPTION
#### Description
In order to check support for a database adapter it is needed to open the database and save an item. This change opens a database with the same name as the database used to store data for the application. This will prevent opening two databases with a size of 5mb requiring a user to click accept on a popup to allow data to be stored.

#### Changes
- add a `loadAdapter()` function to all storage adapters
- Use the name of the application database to check for support of an adapter