### PR TITLE
Register Popup Class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ CacheRack.useCacheMiddleware(new CacheMiddleware());
 NetworkRack.useHttpMiddleware(new HttpMiddleware());
 
 // Setup popup
-User.setPopupClass(Popup);
+User.usePopupClass(Popup);
 
 // Export
 module.exports = Kinvey;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,13 @@
-import Kinvey, { CacheRack, NetworkRack } from 'kinvey-js-sdk/dist/export';
+import Kinvey, { CacheRack, NetworkRack, User } from 'kinvey-js-sdk/dist/export';
 import { CacheMiddleware, HttpMiddleware } from './middleware';
+import Popup from './popup';
 
 // Setup racks
 CacheRack.useCacheMiddleware(new CacheMiddleware());
 NetworkRack.useHttpMiddleware(new HttpMiddleware());
+
+// Setup popup
+User.setPopupClass(Popup);
 
 // Export
 module.exports = Kinvey;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,10 +29,6 @@ module.exports = {
     path: path.resolve(__dirname, './dist')
   },
   plugins: [
-    new webpack.BannerPlugin(BANNER, { raw: true }),
-    new webpack.NormalModuleReplacementPlugin(
-      /kinvey-js-sdk\/dist\/identity\/src\/popup\.js/,
-      require.resolve(path.resolve(__dirname, './dist/popup.js'))
-    )
+    new webpack.BannerPlugin(BANNER, { raw: true })
   ]
 };


### PR DESCRIPTION
#### Description
This PR registers the `Popup` class to use for Mobile Identity Connect using the `usePopupClass()` function on the `User` class.

#### Changes
- Register the `Popup` class in the `index.js` file.
- Remove the logic in the Webpack config to replace the `Popup` class.
